### PR TITLE
Add operator stat page

### DIFF
--- a/src/components/intro.tsx
+++ b/src/components/intro.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, Heading, Text } from '@chakra-ui/react'
 import Link from 'next/link'
 import React from 'react'
-import { EXTERNAL_ROUTES } from '../constants'
+import { EXTERNAL_ROUTES, SYMBOL } from '../constants'
 import { Wallet } from './icons'
 
 export const Intro: React.FC = () => {
@@ -12,7 +12,8 @@ export const Intro: React.FC = () => {
         <Heading ml='2'>Staking as a pool operator</Heading>
       </HStack>
       <Text>
-        tSSC holders (Gemini 3g testnet network only) can stake their tSSC to add more security to the protocol and earn{' '}
+        {SYMBOL} holders (Gemini 3g testnet network only) can stake their {SYMBOL} to add more security to the protocol
+        and earn{' '}
         <u>
           <Link href={EXTERNAL_ROUTES.STAKING_INCENTIVES}>Staking Incentives</Link>
         </u>

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Center, HStack, Spacer, VStack } from '@chakra-ui/react'
 import Link from 'next/link'
 import React from 'react'
+import { ROUTES } from '../constants'
 import { ConnectWallet } from './buttons'
 import { Subspace } from './icons'
 
@@ -11,13 +12,25 @@ interface LayoutProps {
 export const Header: React.FC = () => {
   return (
     <HStack w='50vw' h='10vh' display='flex' flexDir='row'>
-      <Link href='/'>
+      <Link href={ROUTES.HOME}>
         <Subspace />
       </Link>
       <Spacer maxW='18px' />
-      <Button bg='#241235' color='#FFF' borderRadius='9999' pl='16px' pr='16px' pt='8px' pb='7px'>
-        Stake as a pool operator
-      </Button>
+      <Link href={ROUTES.REGISTER}>
+        <Button bg='#241235' color='#FFF' borderRadius='9999' pl='16px' pr='16px' pt='8px' pb='7px'>
+          Stake as a pool operator
+        </Button>
+      </Link>
+      <Link href={ROUTES.MANAGE}>
+        <Button bg='#241235' color='#FFF' borderRadius='9999' pl='16px' pr='16px' pt='8px' pb='7px'>
+          Manage your stake
+        </Button>
+      </Link>
+      <Link href={ROUTES.STATS}>
+        <Button bg='#241235' color='#FFF' borderRadius='9999' pl='16px' pr='16px' pt='8px' pb='7px'>
+          Stats
+        </Button>
+      </Link>
       <Spacer />
       <ConnectWallet />
     </HStack>

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -60,8 +60,8 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
               {operators.map((operator, key) => (
                 <Tr key={key}>
                   <Td isNumeric>{operator.currentDomainId}</Td>
-                  <Td>{key}</Td>
-                  <Td isNumeric>{operator.nominationTax}</Td>
+                  <Td>{formatAddress(stakingConstants.operatorIdOwner[key])}</Td>
+                  <Td isNumeric>{operator.nominationTax}%</Td>
                   <Td isNumeric>{hexToFormattedNumber(operator.minimumNominatorStake)}</Td>
                   <Td isNumeric>{hexToFormattedNumber(operator.currentTotalStake)}</Td>
                 </Tr>

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -23,7 +23,7 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
       <Box mt='6'>
         <HStack mb='6'>
           <Heading size='lg' fontWeight='500' fontSize='40px' ml='2' color='#5B5252'>
-            Aggregated data
+            Information across operators
           </Heading>
           {operatorOwner && (
             <Heading size='lg' fontWeight='500' fontSize='24px' ml='2' mt='16px' color='#5B5252'>

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -1,9 +1,22 @@
 import { Table, TableContainer, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
-import React from 'react'
-import { useRegistration } from '../states/registration'
+import React, { useMemo } from 'react'
+import { useExtension } from '../states/extension'
+import { hexToFormattedNumber } from '../utils'
 
-export const OperatorsList: React.FC = () => {
-  const registrations = useRegistration((state) => state.registrations)
+interface OperatorsListProps {
+  operatorOwner?: string
+}
+
+export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) => {
+  const stakingConstants = useExtension((state) => state.stakingConstants)
+
+  const operators = useMemo(() => {
+    if (operatorOwner)
+      return stakingConstants.operators
+        .map((_, key) => stakingConstants.operatorIdOwner[key][key] === operatorOwner)
+        .map((_, key) => stakingConstants.operators[key])
+    return stakingConstants.operators
+  }, [operatorOwner, stakingConstants.operatorIdOwner, stakingConstants.operators])
 
   return (
     <TableContainer>
@@ -17,7 +30,7 @@ export const OperatorsList: React.FC = () => {
             <Th isNumeric>Funds in stake</Th>
           </Tr>
         </Thead>
-        {registrations.length === 0 ? (
+        {operators.length === 0 ? (
           <Tbody>
             {[0, 1, 2, 3].map((_, key) => (
               <Tr key={key}>
@@ -31,13 +44,13 @@ export const OperatorsList: React.FC = () => {
           </Tbody>
         ) : (
           <Tbody>
-            {registrations.map((registration, key) => (
+            {operators.map((operator, key) => (
               <Tr key={key}>
-                <Td isNumeric>{registration.domainId}</Td>
-                <Td>{registration.signingKey}</Td>
-                <Td isNumeric>{registration.nominatorTax}</Td>
-                <Td isNumeric>{registration.minimumNominatorStake}</Td>
-                <Td isNumeric>{registration.amountToStake}</Td>
+                <Td isNumeric>{operator.currentDomainId}</Td>
+                <Td>{key}</Td>
+                <Td isNumeric>{operator.nominationTax}</Td>
+                <Td isNumeric>{hexToFormattedNumber(operator.minimumNominatorStake)}</Td>
+                <Td isNumeric>{hexToFormattedNumber(operator.currentTotalStake)}</Td>
               </Tr>
             ))}
           </Tbody>

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -1,7 +1,7 @@
-import { Table, TableContainer, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
+import { Box, HStack, Heading, Table, TableContainer, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
 import React, { useMemo } from 'react'
 import { useExtension } from '../states/extension'
-import { hexToFormattedNumber } from '../utils'
+import { formatAddress, hexToFormattedNumber } from '../utils'
 
 interface OperatorsListProps {
   operatorOwner?: string
@@ -19,43 +19,57 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
   }, [operatorOwner, stakingConstants.operatorIdOwner, stakingConstants.operators])
 
   return (
-    <TableContainer>
-      <Table borderColor='#B9B9B9' border='1' variant='striped' size='sm'>
-        <Thead bg='rgba(0, 0, 0, 0.06)'>
-          <Tr>
-            <Th isNumeric>DomainID</Th>
-            <Th>OperatorID</Th>
-            <Th isNumeric>NominatorTax</Th>
-            <Th isNumeric>Min Nominator Stake</Th>
-            <Th isNumeric>Funds in stake</Th>
-          </Tr>
-        </Thead>
-        {operators.length === 0 ? (
-          <Tbody>
-            {[0, 1, 2, 3].map((_, key) => (
-              <Tr key={key}>
-                <Td isNumeric>{key}</Td>
-                <Td></Td>
-                <Td isNumeric></Td>
-                <Td isNumeric></Td>
-                <Td isNumeric></Td>
-              </Tr>
-            ))}
-          </Tbody>
-        ) : (
-          <Tbody>
-            {operators.map((operator, key) => (
-              <Tr key={key}>
-                <Td isNumeric>{operator.currentDomainId}</Td>
-                <Td>{key}</Td>
-                <Td isNumeric>{operator.nominationTax}</Td>
-                <Td isNumeric>{hexToFormattedNumber(operator.minimumNominatorStake)}</Td>
-                <Td isNumeric>{hexToFormattedNumber(operator.currentTotalStake)}</Td>
-              </Tr>
-            ))}
-          </Tbody>
-        )}
-      </Table>
-    </TableContainer>
+    <Box>
+      <Box mt='6'>
+        <HStack mb='6'>
+          <Heading size='lg' fontWeight='500' fontSize='40px' ml='2' color='#5B5252'>
+            Aggregated data
+          </Heading>
+          {operatorOwner && (
+            <Heading size='lg' fontWeight='500' fontSize='24px' ml='2' mt='16px' color='#5B5252'>
+              on Account {formatAddress(operatorOwner)}
+            </Heading>
+          )}
+        </HStack>
+      </Box>
+      <TableContainer>
+        <Table borderColor='#B9B9B9' border='1' variant='striped' size='sm'>
+          <Thead bg='rgba(0, 0, 0, 0.06)'>
+            <Tr>
+              <Th isNumeric>DomainID</Th>
+              <Th>OperatorID</Th>
+              <Th isNumeric>NominatorTax</Th>
+              <Th isNumeric>Min Nominator Stake</Th>
+              <Th isNumeric>Funds in stake</Th>
+            </Tr>
+          </Thead>
+          {operators.length === 0 ? (
+            <Tbody>
+              {[0, 1, 2, 3].map((_, key) => (
+                <Tr key={key}>
+                  <Td isNumeric>{key}</Td>
+                  <Td></Td>
+                  <Td isNumeric></Td>
+                  <Td isNumeric></Td>
+                  <Td isNumeric></Td>
+                </Tr>
+              ))}
+            </Tbody>
+          ) : (
+            <Tbody>
+              {operators.map((operator, key) => (
+                <Tr key={key}>
+                  <Td isNumeric>{operator.currentDomainId}</Td>
+                  <Td>{key}</Td>
+                  <Td isNumeric>{operator.nominationTax}</Td>
+                  <Td isNumeric>{hexToFormattedNumber(operator.minimumNominatorStake)}</Td>
+                  <Td isNumeric>{hexToFormattedNumber(operator.currentTotalStake)}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          )}
+        </Table>
+      </TableContainer>
+    </Box>
   )
 }

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -13,7 +13,7 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
   const operators = useMemo(() => {
     if (operatorOwner)
       return stakingConstants.operators
-        .map((_, key) => stakingConstants.operatorIdOwner[key][key] === operatorOwner)
+        .filter((_, key) => stakingConstants.operatorIdOwner[key] === operatorOwner)
         .map((_, key) => stakingConstants.operators[key])
     return stakingConstants.operators
   }, [operatorOwner, stakingConstants.operatorIdOwner, stakingConstants.operators])

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -1,4 +1,5 @@
 import { Box, HStack, Heading, Table, TableContainer, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
+import Link from 'next/link'
 import React, { useMemo } from 'react'
 import { useExtension } from '../states/extension'
 import { formatAddress, hexToFormattedNumber } from '../utils'
@@ -60,7 +61,11 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
               {operators.map((operator, key) => (
                 <Tr key={key}>
                   <Td isNumeric>{operator.currentDomainId}</Td>
-                  <Td>{formatAddress(stakingConstants.operatorIdOwner[key])}</Td>
+                  <Td>
+                    <Link href={`/operatorStats/${stakingConstants.operatorIdOwner[key]}`}>
+                      {formatAddress(stakingConstants.operatorIdOwner[key])}
+                    </Link>
+                  </Td>
                   <Td isNumeric>{operator.nominationTax}%</Td>
                   <Td isNumeric>{hexToFormattedNumber(operator.minimumNominatorStake)}</Td>
                   <Td isNumeric>{hexToFormattedNumber(operator.currentTotalStake)}</Td>

--- a/src/components/operatorsTotal.tsx
+++ b/src/components/operatorsTotal.tsx
@@ -14,7 +14,7 @@ export const OperatorsTotal: React.FC<OperatorsTotalProps> = ({ operatorOwner })
   const totalFundsInStake = useMemo(() => {
     if (operatorOwner)
       return stakingConstants.operators
-        .map((_, key) => stakingConstants.operatorIdOwner[key][key] === operatorOwner)
+        .filter((_, key) => stakingConstants.operatorIdOwner[key] === operatorOwner)
         .map((_, key) => stakingConstants.operators[key])
         .reduce((acc, operator) => acc + hexToNumber(operator.currentTotalStake), 0)
     return stakingConstants.operators.reduce((acc, operator) => acc + hexToNumber(operator.currentTotalStake), 0)

--- a/src/components/operatorsTotal.tsx
+++ b/src/components/operatorsTotal.tsx
@@ -1,38 +1,74 @@
-import { Grid, GridItem, Text } from '@chakra-ui/react'
+import { Box, Grid, GridItem, HStack, Heading, Text } from '@chakra-ui/react'
 import React, { useMemo } from 'react'
 import { SYMBOL, textStyles } from '../constants'
-import { useRegistration } from '../states/registration'
-import { formatNumber } from '../utils'
+import { useExtension } from '../states/extension'
+import { formatAddress, formatNumber, hexToNumber } from '../utils'
 
-export const OperatorsTotal: React.FC = () => {
-  const registrations = useRegistration((state) => state.registrations)
+interface OperatorsTotalProps {
+  operatorOwner?: string
+}
 
-  const totalFundsInStake = useMemo(
-    () => registrations.reduce((acc, registration) => acc + parseInt(registration.amountToStake), 0),
-    [registrations]
-  )
-  const totalNominators = useMemo(() => registrations.length, [registrations])
+export const OperatorsTotal: React.FC<OperatorsTotalProps> = ({ operatorOwner }) => {
+  const stakingConstants = useExtension((state) => state.stakingConstants)
+
+  const totalFundsInStake = useMemo(() => {
+    if (operatorOwner)
+      return stakingConstants.operators
+        .map((_, key) => stakingConstants.operatorIdOwner[key][key] === operatorOwner)
+        .map((_, key) => stakingConstants.operators[key])
+        .reduce((acc, operator) => acc + hexToNumber(operator.currentTotalStake), 0)
+    return stakingConstants.operators.reduce((acc, operator) => acc + hexToNumber(operator.currentTotalStake), 0)
+  }, [operatorOwner, stakingConstants.operatorIdOwner, stakingConstants.operators])
+
+  // To-Do: Implement this
+  const totalFundsInStakeAvailable = useMemo(() => {
+    return totalFundsInStake
+  }, [totalFundsInStake])
+
+  // To-Do: Implement this
+  const totalNominators = useMemo(() => {
+    return 0
+  }, [])
+
+  // To-Do: Implement this
+  const totalNominatorsStake = useMemo(() => {
+    return 0
+  }, [])
 
   return (
-    <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12'>
-      <GridItem w='100%'>
-        <Text style={textStyles.heading}>Funds in Stake, {SYMBOL}</Text>
-        <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
+    <Box>
+      <Box mt='6'>
+        <HStack mb='6'>
+          <Heading size='lg' fontWeight='500' fontSize='40px' ml='2' color='#5B5252'>
+            Aggregated data
+          </Heading>
+          {operatorOwner && (
+            <Heading size='lg' fontWeight='500' fontSize='24px' ml='2' mt='16px' color='#5B5252'>
+              on Account {formatAddress(operatorOwner)}
+            </Heading>
+          )}
+        </HStack>
+      </Box>
+      <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12'>
+        <GridItem w='100%'>
+          <Text style={textStyles.heading}>Funds in Stake, {SYMBOL}</Text>
+          <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
 
-        <Text style={textStyles.heading} mt='8'>
-          Number of Nominators
-        </Text>
-        <Text style={textStyles.value}>{totalNominators}</Text>
-      </GridItem>
-      <GridItem w='100%'>
-        <Text style={textStyles.heading}>Available for withdrawal, {SYMBOL}</Text>
-        <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
+          <Text style={textStyles.heading} mt='8'>
+            Number of Nominators
+          </Text>
+          <Text style={textStyles.value}>{totalNominators}</Text>
+        </GridItem>
+        <GridItem w='100%'>
+          <Text style={textStyles.heading}>Available for withdrawal, {SYMBOL}</Text>
+          <Text style={textStyles.value}>{formatNumber(totalFundsInStakeAvailable)}</Text>
 
-        <Text style={textStyles.heading} mt='8'>
-          Nominator’s funds, {SYMBOL}
-        </Text>
-        <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
-      </GridItem>
-    </Grid>
+          <Text style={textStyles.heading} mt='8'>
+            Nominator’s funds, {SYMBOL}
+          </Text>
+          <Text style={textStyles.value}>{formatNumber(totalNominatorsStake)}</Text>
+        </GridItem>
+      </Grid>
+    </Box>
   )
 }

--- a/src/components/operatorsTotal.tsx
+++ b/src/components/operatorsTotal.tsx
@@ -1,6 +1,6 @@
 import { Grid, GridItem, Text } from '@chakra-ui/react'
 import React, { useMemo } from 'react'
-import { textStyles } from '../constants'
+import { SYMBOL, textStyles } from '../constants'
 import { useRegistration } from '../states/registration'
 import { formatNumber } from '../utils'
 
@@ -16,7 +16,7 @@ export const OperatorsTotal: React.FC = () => {
   return (
     <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12'>
       <GridItem w='100%'>
-        <Text style={textStyles.heading}>Funds in Stake, tSSC</Text>
+        <Text style={textStyles.heading}>Funds in Stake, {SYMBOL}</Text>
         <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
 
         <Text style={textStyles.heading} mt='8'>
@@ -25,11 +25,11 @@ export const OperatorsTotal: React.FC = () => {
         <Text style={textStyles.value}>{totalNominators}</Text>
       </GridItem>
       <GridItem w='100%'>
-        <Text style={textStyles.heading}>Available for withdrawal, tSSC</Text>
+        <Text style={textStyles.heading}>Available for withdrawal, {SYMBOL}</Text>
         <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
 
         <Text style={textStyles.heading} mt='8'>
-          Nominator’s funds, tSSC
+          Nominator’s funds, {SYMBOL}
         </Text>
         <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
       </GridItem>

--- a/src/components/wallet.tsx
+++ b/src/components/wallet.tsx
@@ -20,8 +20,10 @@ import {
   Text,
   VStack
 } from '@chakra-ui/react'
+import { encodeAddress } from '@polkadot/keyring'
 import Image from 'next/image'
 import { useRef } from 'react'
+import { SUBSPACE_ACCOUNT_FORMAT } from '../constants'
 import { useConnect } from '../hooks/useConnect'
 import { useExtension } from '../states/extension'
 import { formatAddress } from '../utils'
@@ -45,6 +47,7 @@ const ExtensionIcon: React.FC<ExtensionIconProps> = ({ extension }) => {
 
 export const ConnectWallet = () => {
   const extension = useExtension((state) => state.extension)
+  const subspaceAccount = useExtension((state) => state.subspaceAccount)
   const {
     handleSelectFirstWalletFromExtension,
     handleSelectWallet,
@@ -57,7 +60,7 @@ export const ConnectWallet = () => {
 
   return (
     <>
-      {!extension.data ? (
+      {!extension.data || !subspaceAccount ? (
         <Button
           bgGradient='linear(to-r, #EA71F9, #4D397A)'
           color='#FFFFFF'
@@ -90,7 +93,7 @@ export const ConnectWallet = () => {
             _hover={{
               bgGradient: 'linear(to-r, #4D397A, #EA71F9)'
             }}>
-            {formatAddress(extension.data.defaultAccount.address)}
+            {formatAddress(subspaceAccount)}
           </MenuButton>
           <MenuList>
             {extension.data.accounts.map((account) => (
@@ -101,7 +104,7 @@ export const ConnectWallet = () => {
                   bgGradient: 'linear(to-r, #A28CD2, #F4ABFD)'
                 }}>
                 <ExtensionIcon extension={account.meta.source} />
-                <Text ml='2'>{formatAddress(account.address)}</Text>
+                <Text ml='2'>{formatAddress(encodeAddress(account.address, SUBSPACE_ACCOUNT_FORMAT))}</Text>
               </MenuItem>
             ))}
             <MenuDivider />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -17,6 +17,8 @@ export const EXTERNAL_ROUTES = {
 
 export const SUBSPACE_EXTENSION_ID = 'subspace-staking-interface'
 
+export const SUBSPACE_ACCOUNT_FORMAT = 2254
+
 export const SYMBOL = 'tSSC'
 
 export enum ActionType {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -48,8 +48,7 @@ export const initialStakingConstants: StakingConstants = {
   domainStakingSummary: [],
   operatorIdOwner: [],
   operators: [],
-  pendingStakingOperationCount: [],
-  nominatorCount: []
+  pendingStakingOperationCount: []
 }
 
 export const toastConfig = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,7 +5,8 @@ export * from './styles'
 export const ROUTES = {
   HOME: '/',
   REGISTER: '/register',
-  MANAGE: '/manage'
+  MANAGE: '/manage',
+  STATS: '/stats'
 }
 
 export const EXTERNAL_ROUTES = {
@@ -47,7 +48,8 @@ export const initialStakingConstants: StakingConstants = {
   domainStakingSummary: [],
   operatorIdOwner: [],
   operators: [],
-  pendingStakingOperationCount: []
+  pendingStakingOperationCount: [],
+  nominatorCount: []
 }
 
 export const toastConfig = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -16,6 +16,8 @@ export const EXTERNAL_ROUTES = {
 
 export const SUBSPACE_EXTENSION_ID = 'subspace-staking-interface'
 
+export const SYMBOL = 'tSSC'
+
 export enum ActionType {
   Deregister = 'deregister',
   AddFunds = 'addFunds',

--- a/src/hooks/useConnect.ts
+++ b/src/hooks/useConnect.ts
@@ -1,6 +1,7 @@
 import { useDisclosure } from '@chakra-ui/react'
 import { ApiPromise } from '@polkadot/api'
 import { web3Accounts, web3Enable } from '@polkadot/extension-dapp'
+import { encodeAddress } from '@polkadot/keyring'
 import { WsProvider } from '@polkadot/rpc-provider'
 import { useCallback, useEffect } from 'react'
 import { SUBSPACE_EXTENSION_ID, initialExtensionValues } from '../constants'
@@ -19,6 +20,7 @@ export const useConnect = () => {
   const api = useExtension((state) => state.api)
   const setApi = useExtension((state) => state.setApi)
   const setExtension = useExtension((state) => state.setExtension)
+  const setSubspaceAccount = useExtension((state) => state.setSubspaceAccount)
   const setInjectedExtension = useExtension((state) => state.setInjectedExtension)
   const setAccountDetails = useExtension((state) => state.setAccountDetails)
   const setStakingConstants = useExtension((state) => state.setStakingConstants)
@@ -120,7 +122,7 @@ export const useConnect = () => {
       await handleConnect()
       const mainAccount = extension.data?.accounts.find((account) => account.meta.source === source)
       console.log('mainAccount', mainAccount)
-      if (mainAccount && extension.data)
+      if (mainAccount && extension.data) {
         setExtension({
           ...extension,
           data: {
@@ -128,16 +130,18 @@ export const useConnect = () => {
             defaultAccount: mainAccount
           }
         })
+        setSubspaceAccount(encodeAddress(mainAccount.address, 2258))
+      }
       onConnectClose()
     },
-    [handleConnect, extension, setExtension, onConnectClose]
+    [handleConnect, extension, onConnectClose, setExtension, setSubspaceAccount]
   )
 
   const handleSelectWallet = useCallback(
     async (address: string) => {
       const mainAccount = extension.data?.accounts.find((account) => account.address === address)
       console.log('mainAccount', mainAccount)
-      if (mainAccount && extension.data)
+      if (mainAccount && extension.data) {
         setExtension({
           ...extension,
           data: {
@@ -145,8 +149,10 @@ export const useConnect = () => {
             defaultAccount: mainAccount
           }
         })
+        setSubspaceAccount(encodeAddress(mainAccount.address, 2258))
+      }
     },
-    [extension, setExtension]
+    [extension, setExtension, setSubspaceAccount]
   )
 
   const handleRefreshBalance = useCallback(async () => {

--- a/src/hooks/useOnchainData.ts
+++ b/src/hooks/useOnchainData.ts
@@ -2,13 +2,7 @@ import { ApiPromise } from '@polkadot/api'
 import { WsProvider } from '@polkadot/rpc-provider'
 import { useCallback } from 'react'
 import { useExtension } from '../states/extension'
-import {
-  DomainRegistry,
-  DomainStakingSummary,
-  OperatorIdOwner,
-  Operators,
-  PendingStakingOperationCount
-} from '../types'
+import { DomainRegistry, DomainStakingSummary, Operators, PendingStakingOperationCount } from '../types'
 
 export const useOnchainData = () => {
   const setApi = useExtension((state) => state.setApi)
@@ -42,7 +36,7 @@ export const useOnchainData = () => {
         const operatorIdOwner = await _api.query.domains.operatorIdOwner.entries()
         console.log(
           'operatorIdOwner',
-          operatorIdOwner.map((operator) => operator[1].toJSON() as OperatorIdOwner)
+          operatorIdOwner.map((operator) => operator[1].toJSON() as string)
         )
 
         const operators = await _api.query.domains.operators.entries()
@@ -64,7 +58,7 @@ export const useOnchainData = () => {
           stakeWithdrawalLockingPeriod: Number(stakeWithdrawalLockingPeriod.toString()),
           domainRegistry: domainRegistry.map((domain) => domain[1].toJSON() as DomainRegistry),
           domainStakingSummary: domainStakingSummary.map((domain) => domain[1].toJSON() as DomainStakingSummary),
-          operatorIdOwner: operatorIdOwner.map((operator) => operator[1].toJSON() as OperatorIdOwner),
+          operatorIdOwner: operatorIdOwner.map((operator) => operator[1].toJSON() as string),
           operators: operators.map((operator) => operator[1].toJSON() as Operators),
           pendingStakingOperationCount: pendingStakingOperationCount.map(
             (operator) => operator[1].toJSON() as PendingStakingOperationCount

--- a/src/hooks/useOnchainData.ts
+++ b/src/hooks/useOnchainData.ts
@@ -1,0 +1,82 @@
+import { ApiPromise } from '@polkadot/api'
+import { WsProvider } from '@polkadot/rpc-provider'
+import { useCallback } from 'react'
+import { useExtension } from '../states/extension'
+import {
+  DomainRegistry,
+  DomainStakingSummary,
+  OperatorIdOwner,
+  Operators,
+  PendingStakingOperationCount
+} from '../types'
+
+export const useOnchainData = () => {
+  const setApi = useExtension((state) => state.setApi)
+  const setStakingConstants = useExtension((state) => state.setStakingConstants)
+
+  const handleOnchainData = useCallback(async () => {
+    try {
+      if (!process.env.NEXT_PUBLIC_PROVIDER_URL) throw new Error('NEXT_PUBLIC_PROVIDER_URL not set')
+
+      const wsProvider = new WsProvider(process.env.NEXT_PUBLIC_PROVIDER_URL)
+      const _api = await ApiPromise.create({ provider: wsProvider })
+      if (_api) {
+        console.log('Connection Success')
+        setApi(_api)
+        const { maxNominators, minOperatorStake, stakeEpochDuration, stakeWithdrawalLockingPeriod } =
+          _api.consts.domains
+        console.log('stakimg', _api.consts.domains)
+
+        const domainRegistry = await _api.query.domains.domainRegistry.entries()
+        console.log(
+          'domainRegistry',
+          domainRegistry.map((domain) => domain[1].toJSON() as DomainRegistry)
+        )
+
+        const domainStakingSummary = await _api.query.domains.domainStakingSummary.entries()
+        console.log(
+          'domainStakingSummary',
+          domainStakingSummary.map((domain) => domain[1].toJSON() as DomainStakingSummary)
+        )
+
+        const operatorIdOwner = await _api.query.domains.operatorIdOwner.entries()
+        console.log(
+          'operatorIdOwner',
+          operatorIdOwner.map((operator) => operator[1].toJSON() as OperatorIdOwner)
+        )
+
+        const operators = await _api.query.domains.operators.entries()
+        console.log(
+          'operators',
+          operators.map((operator) => operator[1].toJSON() as Operators)
+        )
+
+        const pendingStakingOperationCount = await _api.query.domains.pendingStakingOperationCount.entries()
+        console.log(
+          'pendingStakingOperationCount',
+          pendingStakingOperationCount.map((operator) => operator[1].toJSON() as PendingStakingOperationCount)
+        )
+
+        setStakingConstants({
+          maxNominators: Number(maxNominators.toString()),
+          minOperatorStake: BigInt(minOperatorStake.toString()),
+          stakeEpochDuration: Number(stakeEpochDuration.toString()),
+          stakeWithdrawalLockingPeriod: Number(stakeWithdrawalLockingPeriod.toString()),
+          domainRegistry: domainRegistry.map((domain) => domain[1].toJSON() as DomainRegistry),
+          domainStakingSummary: domainStakingSummary.map((domain) => domain[1].toJSON() as DomainStakingSummary),
+          operatorIdOwner: operatorIdOwner.map((operator) => operator[1].toJSON() as OperatorIdOwner),
+          operators: operators.map((operator) => operator[1].toJSON() as Operators),
+          pendingStakingOperationCount: pendingStakingOperationCount.map(
+            (operator) => operator[1].toJSON() as PendingStakingOperationCount
+          )
+        })
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }, [setApi, setStakingConstants])
+
+  return {
+    handleOnchainData
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,22 @@
 import { Box, Heading, Text } from '@chakra-ui/react'
 import Image from 'next/image'
 import Link from 'next/link'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { ConnectWallet, FormButton } from '../components/buttons'
 import { Intro } from '../components/intro'
 import { EXTERNAL_ROUTES, ROUTES } from '../constants'
+import { useOnchainData } from '../hooks/useOnchainData'
 import { useWallet } from '../hooks/useWallet'
+import { useExtension } from '../states/extension'
 
 const Page: React.FC = () => {
+  const subspaceAccount = useExtension((state) => state.subspaceAccount)
   const { extension, handleConnect } = useWallet()
+  const { handleOnchainData } = useOnchainData()
+
+  useEffect(() => {
+    handleOnchainData()
+  }, [handleOnchainData, subspaceAccount])
 
   return (
     <Box minW='60vw' maxW='60vw' mt='10' p='4' border='0'>

--- a/src/pages/manage.tsx
+++ b/src/pages/manage.tsx
@@ -28,7 +28,7 @@ import { useRegistration } from '../states/registration'
 
 const Page: React.FC = () => {
   const isErrorsField = useRegistration((state) => state.isErrorsField)
-  const extension = useExtension((state) => state.extension)
+  const subspaceAccount = useExtension((state) => state.subspaceAccount)
   const { handleChange, handleMaxAmountToAddFunds, handleSubmit } = useManage()
 
   return (
@@ -37,7 +37,7 @@ const Page: React.FC = () => {
         <Wallet />
         <Heading ml='2'>Manage the stake</Heading>
       </HStack>
-      <OperatorsList operatorOwner={extension.data ? extension.data.defaultAccount.address : undefined} />
+      <OperatorsList operatorOwner={subspaceAccount} />
       <Flex>
         <Spacer />
         <Box>
@@ -80,7 +80,7 @@ const Page: React.FC = () => {
         </Box>
       </Flex>
       <Box>
-        <OperatorsTotal operatorOwner={extension.data ? extension.data.defaultAccount.address : undefined} />
+        <OperatorsTotal operatorOwner={subspaceAccount} />
         <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12' mb='24'>
           <GridItem w='100%'>
             <FormControl isInvalid={isErrorsField['operatorId']}>

--- a/src/pages/manage.tsx
+++ b/src/pages/manage.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Center,
   Flex,
   FormControl,
   FormErrorMessage,
@@ -16,20 +17,28 @@ import {
   Spacer,
   Text
 } from '@chakra-ui/react'
-import React from 'react'
-import { FormButton } from '../components/buttons'
+import React, { useEffect } from 'react'
+import { ConnectWallet, FormButton } from '../components/buttons'
 import { Wallet } from '../components/icons'
 import { OperatorsList } from '../components/operatorsList'
 import { OperatorsTotal } from '../components/operatorsTotal'
 import { ActionType, SYMBOL } from '../constants'
 import { useManage } from '../hooks/useManage'
+import { useOnchainData } from '../hooks/useOnchainData'
+import { useWallet } from '../hooks/useWallet'
 import { useExtension } from '../states/extension'
 import { useRegistration } from '../states/registration'
 
 const Page: React.FC = () => {
   const isErrorsField = useRegistration((state) => state.isErrorsField)
   const subspaceAccount = useExtension((state) => state.subspaceAccount)
+  const { handleConnect } = useWallet()
   const { handleChange, handleMaxAmountToAddFunds, handleSubmit } = useManage()
+  const { handleOnchainData } = useOnchainData()
+
+  useEffect(() => {
+    handleOnchainData()
+  }, [handleOnchainData, subspaceAccount])
 
   return (
     <Box minW='60vw' maxW='60vw' mt='10' p='4' border='0'>
@@ -37,138 +46,153 @@ const Page: React.FC = () => {
         <Wallet />
         <Heading ml='2'>Manage the stake</Heading>
       </HStack>
-      <OperatorsList operatorOwner={subspaceAccount} />
-      <Flex>
-        <Spacer />
-        <Box>
-          <HStack mb='2' w='100%' alignItems='flex-end' textAlign='right' alignContent='flex-end'>
-            <Text color='#6C6666' pt='2' pb='2'>
-              Operator deregistration
-            </Text>
-            <Input
-              placeholder='Operator ID'
-              bg='#FFFFFF'
-              borderColor='#141414'
-              color='#7D7D7D'
-              mt='4'
-              w='48'
-              borderRadius='5'
-              pl='16px'
-              pr='16px'
-              pt='8px'
-              pb='7px'
-              onChange={(e) => handleChange(ActionType.Deregister, e)}
-              _placeholder={{
-                color: '#7D7D7D'
-              }}
-            />
-            <Button
-              bg='#999393'
-              borderColor='#EAEBEF'
-              color='#FFFFFF'
-              mt='4'
-              w='124px'
-              borderRadius='0'
-              pl='16px'
-              pr='16px'
-              pt='8px'
-              pb='7px'
-              onClick={() => handleSubmit(ActionType.Deregister)}>
-              De-register
-            </Button>
-          </HStack>
-        </Box>
-      </Flex>
-      <Box>
-        <OperatorsTotal operatorOwner={subspaceAccount} />
-        <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12' mb='24'>
-          <GridItem w='100%'>
-            <FormControl isInvalid={isErrorsField['operatorId']}>
-              <FormLabel fontWeight='500' fontSize='40px' color='#5B5252'>
-                Add more funds
-              </FormLabel>
-              <Input
-                name='operatorId'
-                mt='4'
-                borderColor='#141414'
-                border='1px'
-                w='479px'
-                placeholder='Operator ID'
-                onChange={(e) => handleChange(ActionType.AddFunds, e)}
-                _placeholder={{ color: '#7D7D7D' }}
-              />
-              {isErrorsField['operatorId'] ? (
-                <FormErrorMessage h='10'>The operator id you enter is not valid</FormErrorMessage>
-              ) : (
-                <FormHelperText h='10'></FormHelperText>
-              )}
-            </FormControl>
-            <FormControl isInvalid={isErrorsField['amount']}>
-              <InputGroup size='md' mt='4'>
+      {subspaceAccount ? (
+        <>
+          <OperatorsList operatorOwner={subspaceAccount} />
+          <Flex>
+            <Spacer />
+            <Box>
+              <HStack mb='2' w='100%' alignItems='flex-end' textAlign='right' alignContent='flex-end'>
+                <Text color='#6C6666' pt='2' pb='2'>
+                  Operator deregistration
+                </Text>
                 <Input
-                  name='amount'
+                  placeholder='Operator ID'
+                  bg='#FFFFFF'
                   borderColor='#141414'
-                  border='1px'
-                  w='479px'
-                  placeholder={`Amount, ${SYMBOL}`}
-                  onChange={(e) => handleChange(ActionType.AddFunds, e)}
-                  _placeholder={{ color: '#7D7D7D' }}
+                  color='#7D7D7D'
+                  mt='4'
+                  w='48'
+                  borderRadius='5'
+                  pl='16px'
+                  pr='16px'
+                  pt='8px'
+                  pb='7px'
+                  onChange={(e) => handleChange(ActionType.Deregister, e)}
+                  _placeholder={{
+                    color: '#7D7D7D'
+                  }}
                 />
-                <InputRightElement>
-                  <Button m={1} onClick={handleMaxAmountToAddFunds}>
-                    Max
-                  </Button>
-                </InputRightElement>
-              </InputGroup>
-              {isErrorsField['amount'] ? (
-                <FormErrorMessage h='10'>The amount you enter is not valid</FormErrorMessage>
-              ) : (
-                <FormHelperText h='10'></FormHelperText>
-              )}
-            </FormControl>
-            <FormButton onClick={() => handleSubmit(ActionType.AddFunds)}>Add more funds</FormButton>
-          </GridItem>
-          <GridItem w='100%'>
-            <FormControl isInvalid={isErrorsField['operatorId']}>
-              <FormLabel fontWeight='500' fontSize='40px' color='#5B5252'>
-                Initiate a withdrawal
-              </FormLabel>
-              <Input
-                name='operatorId'
-                mt='4'
-                borderColor='#141414'
-                border='1px'
-                w='479px'
-                placeholder='Operator ID'
-                onChange={(e) => handleChange(ActionType.Withdraw, e)}
-                _placeholder={{ color: '#7D7D7D' }}
-              />
-              {isErrorsField['operatorId'] ? (
-                <FormErrorMessage h='10'>The operator id you enter is not valid</FormErrorMessage>
-              ) : (
-                <FormHelperText h='10'></FormHelperText>
-              )}
-            </FormControl>
-            <FormControl isInvalid={isErrorsField['amount']}>
-              <Input
-                name='amount'
-                borderColor='#141414'
-                border='1px'
-                w='479px'
-                placeholder={`Amount, ${SYMBOL}`}
-                onChange={(e) => handleChange(ActionType.Withdraw, e)}
-                _placeholder={{ color: '#7D7D7D' }}
-              />
-              {isErrorsField['amount'] ? (
-                <FormErrorMessage h='10'>The amount you enter is not valid</FormErrorMessage>
-              ) : (
-                <FormHelperText h='10'></FormHelperText>
-              )}
-            </FormControl>
-            <FormButton onClick={() => handleSubmit(ActionType.Withdraw)}>Submit</FormButton>
-          </GridItem>
-        </Grid>
-      </Box>
+                <Button
+                  bg='#999393'
+                  borderColor='#EAEBEF'
+                  color='#FFFFFF'
+                  mt='4'
+                  w='124px'
+                  borderRadius='0'
+                  pl='16px'
+                  pr='16px'
+                  pt='8px'
+                  pb='7px'
+                  onClick={() => handleSubmit(ActionType.Deregister)}>
+                  De-register
+                </Button>
+              </HStack>
+            </Box>
+          </Flex>
+          <Box>
+            <OperatorsTotal operatorOwner={subspaceAccount} />
+            <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12' mb='24'>
+              <GridItem w='100%'>
+                <FormControl isInvalid={isErrorsField['operatorId']}>
+                  <FormLabel fontWeight='500' fontSize='40px' color='#5B5252'>
+                    Add more funds
+                  </FormLabel>
+                  <Input
+                    name='operatorId'
+                    mt='4'
+                    borderColor='#141414'
+                    border='1px'
+                    w='479px'
+                    placeholder='Operator ID'
+                    onChange={(e) => handleChange(ActionType.AddFunds, e)}
+                    _placeholder={{ color: '#7D7D7D' }}
+                  />
+                  {isErrorsField['operatorId'] ? (
+                    <FormErrorMessage h='10'>The operator id you enter is not valid</FormErrorMessage>
+                  ) : (
+                    <FormHelperText h='10'></FormHelperText>
+                  )}
+                </FormControl>
+                <FormControl isInvalid={isErrorsField['amount']}>
+                  <InputGroup size='md' mt='4'>
+                    <Input
+                      name='amount'
+                      borderColor='#141414'
+                      border='1px'
+                      w='479px'
+                      placeholder={`Amount, ${SYMBOL}`}
+                      onChange={(e) => handleChange(ActionType.AddFunds, e)}
+                      _placeholder={{ color: '#7D7D7D' }}
+                    />
+                    <InputRightElement>
+                      <Button m={1} onClick={handleMaxAmountToAddFunds}>
+                        Max
+                      </Button>
+                    </InputRightElement>
+                  </InputGroup>
+                  {isErrorsField['amount'] ? (
+                    <FormErrorMessage h='10'>The amount you enter is not valid</FormErrorMessage>
+                  ) : (
+                    <FormHelperText h='10'></FormHelperText>
+                  )}
+                </FormControl>
+                <FormButton onClick={() => handleSubmit(ActionType.AddFunds)}>Add more funds</FormButton>
+              </GridItem>
+              <GridItem w='100%'>
+                <FormControl isInvalid={isErrorsField['operatorId']}>
+                  <FormLabel fontWeight='500' fontSize='40px' color='#5B5252'>
+                    Initiate a withdrawal
+                  </FormLabel>
+                  <Input
+                    name='operatorId'
+                    mt='4'
+                    borderColor='#141414'
+                    border='1px'
+                    w='479px'
+                    placeholder='Operator ID'
+                    onChange={(e) => handleChange(ActionType.Withdraw, e)}
+                    _placeholder={{ color: '#7D7D7D' }}
+                  />
+                  {isErrorsField['operatorId'] ? (
+                    <FormErrorMessage h='10'>The operator id you enter is not valid</FormErrorMessage>
+                  ) : (
+                    <FormHelperText h='10'></FormHelperText>
+                  )}
+                </FormControl>
+                <FormControl isInvalid={isErrorsField['amount']}>
+                  <Input
+                    name='amount'
+                    borderColor='#141414'
+                    border='1px'
+                    w='479px'
+                    placeholder={`Amount, ${SYMBOL}`}
+                    onChange={(e) => handleChange(ActionType.Withdraw, e)}
+                    _placeholder={{ color: '#7D7D7D' }}
+                  />
+                  {isErrorsField['amount'] ? (
+                    <FormErrorMessage h='10'>The amount you enter is not valid</FormErrorMessage>
+                  ) : (
+                    <FormHelperText h='10'></FormHelperText>
+                  )}
+                </FormControl>
+                <FormButton onClick={() => handleSubmit(ActionType.Withdraw)}>Submit</FormButton>
+              </GridItem>
+            </Grid>
+          </Box>
+        </>
+      ) : (
+        <Box mt='4'>
+          <Center>
+            <Text color='#6C6666' pt='2' pb='2'>
+              Please connect your wallet
+            </Text>
+          </Center>
+          <Center>
+            <ConnectWallet onClick={handleConnect} />
+          </Center>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/pages/manage.tsx
+++ b/src/pages/manage.tsx
@@ -21,7 +21,7 @@ import { FormButton } from '../components/buttons'
 import { Wallet } from '../components/icons'
 import { OperatorsList } from '../components/operatorsList'
 import { OperatorsTotal } from '../components/operatorsTotal'
-import { ActionType } from '../constants'
+import { ActionType, SYMBOL } from '../constants'
 import { useManage } from '../hooks/useManage'
 import { useExtension } from '../states/extension'
 import { useRegistration } from '../states/registration'
@@ -131,7 +131,7 @@ const Page: React.FC = () => {
                   borderColor='#141414'
                   border='1px'
                   w='479px'
-                  placeholder='Amount, tSSC'
+                  placeholder={`Amount, ${SYMBOL}`}
                   onChange={(e) => handleChange(ActionType.AddFunds, e)}
                   _placeholder={{ color: '#7D7D7D' }}
                 />
@@ -176,7 +176,7 @@ const Page: React.FC = () => {
                 borderColor='#141414'
                 border='1px'
                 w='479px'
-                placeholder='Amount, tSSC'
+                placeholder={`Amount, ${SYMBOL}`}
                 onChange={(e) => handleChange(ActionType.Withdraw, e)}
                 _placeholder={{ color: '#7D7D7D' }}
               />

--- a/src/pages/manage.tsx
+++ b/src/pages/manage.tsx
@@ -25,7 +25,6 @@ import { ActionType, SYMBOL } from '../constants'
 import { useManage } from '../hooks/useManage'
 import { useExtension } from '../states/extension'
 import { useRegistration } from '../states/registration'
-import { formatAddress } from '../utils'
 
 const Page: React.FC = () => {
   const isErrorsField = useRegistration((state) => state.isErrorsField)
@@ -38,19 +37,7 @@ const Page: React.FC = () => {
         <Wallet />
         <Heading ml='2'>Manage the stake</Heading>
       </HStack>
-      <Box mt='6'>
-        <HStack mb='6'>
-          <Heading size='lg' fontWeight='500' fontSize='40px' ml='2' color='#5B5252'>
-            Information across operators
-          </Heading>
-          {extension.data && (
-            <Heading size='lg' fontWeight='500' fontSize='24px' ml='2' mt='16px' color='#5B5252'>
-              on SigningKey {formatAddress(extension.data.defaultAccount.address)}
-            </Heading>
-          )}
-        </HStack>
-      </Box>
-      <OperatorsList />
+      <OperatorsList operatorOwner={extension.data ? extension.data.defaultAccount.address : undefined} />
       <Flex>
         <Spacer />
         <Box>
@@ -93,15 +80,7 @@ const Page: React.FC = () => {
         </Box>
       </Flex>
       <Box>
-        <HStack mb='6'>
-          <Heading size='lg' fontWeight='500' fontSize='40px' ml='2' color='#5B5252'>
-            Aggregated data
-          </Heading>
-          <Heading size='lg' fontWeight='500' fontSize='24px' ml='2' mt='16px' color='#5B5252'>
-            on SigningKey st9450943...04953
-          </Heading>
-        </HStack>
-        <OperatorsTotal />
+        <OperatorsTotal operatorOwner={extension.data ? extension.data.defaultAccount.address : undefined} />
         <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12' mb='24'>
           <GridItem w='100%'>
             <FormControl isInvalid={isErrorsField['operatorId']}>

--- a/src/pages/operatorStats/[operatorOwner].tsx
+++ b/src/pages/operatorStats/[operatorOwner].tsx
@@ -1,0 +1,46 @@
+import { Box, HStack, Heading } from '@chakra-ui/react'
+import { GetStaticPaths } from 'next'
+import { useRouter } from 'next/router'
+import React, { useEffect, useMemo } from 'react'
+import { Wallet } from '../../components/icons'
+import { OperatorsList } from '../../components/operatorsList'
+import { OperatorsTotal } from '../../components/operatorsTotal'
+import { useOnchainData } from '../../hooks/useOnchainData'
+
+const Page: React.FC = () => {
+  const { handleOnchainData } = useOnchainData()
+  const { query } = useRouter()
+
+  useEffect(() => {
+    handleOnchainData()
+  }, [handleOnchainData])
+
+  const operatorOwner = useMemo(() => {
+    if (query.operatorOwner && typeof query.operatorOwner === 'string') return query.operatorOwner as string
+    return ''
+  }, [query])
+
+  return (
+    <Box minW='60vw' maxW='60vw' mt='10' p='4' border='0'>
+      <HStack>
+        <Wallet />
+        <Heading ml='2'>Stats</Heading>
+      </HStack>
+      <OperatorsList operatorOwner={operatorOwner} />
+      <OperatorsTotal operatorOwner={operatorOwner} />
+    </Box>
+  )
+}
+
+export async function getStaticProps() {
+  return { props: { title: 'Subspace Staking Interface - Stats' } }
+}
+
+export const getStaticPaths: GetStaticPaths<{ operatorOwner: string }> = async () => {
+  return {
+    paths: [{ params: { operatorOwner: 'st00' } }],
+    fallback: true
+  }
+}
+
+export default Page

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -18,6 +18,7 @@ import Link from 'next/link'
 import React from 'react'
 import { ConnectWallet, FormButton } from '../components/buttons'
 import { Intro } from '../components/intro'
+import { SYMBOL } from '../constants'
 import { useRegister } from '../hooks/useRegister'
 import { useWallet } from '../hooks/useWallet'
 import { useRegistration } from '../states/registration'
@@ -54,7 +55,7 @@ const Page: React.FC = () => {
               )}
             </FormControl>
             <FormControl isInvalid={isErrorsField['amountToStake']}>
-              <FormLabel>Amount to stake, tSSC</FormLabel>
+              <FormLabel>Amount to stake, {SYMBOL}</FormLabel>
               <InputGroup size='md' mt='4'>
                 <Input name='amountToStake' value={amountToStake} onChange={handleChange} />
                 <InputRightElement>
@@ -81,7 +82,7 @@ const Page: React.FC = () => {
           </GridItem>
           <GridItem w='100%'>
             <FormControl isInvalid={isErrorsField['minimumNominatorStake']}>
-              <FormLabel>Minimum Nominator Stake, tSSC</FormLabel>
+              <FormLabel>Minimum Nominator Stake, {SYMBOL}</FormLabel>
               <Input name='minimumNominatorStake' value={minimumNominatorStake} onChange={handleChange} mt='4' />
               {isErrorsField['minimumNominatorStake'] ? (
                 <FormErrorMessage h='10'>The minimum nominator stake you enter is not valid</FormErrorMessage>

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -15,10 +15,11 @@ import {
 } from '@chakra-ui/react'
 import { Select } from 'chakra-react-select'
 import Link from 'next/link'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { ConnectWallet, FormButton } from '../components/buttons'
 import { Intro } from '../components/intro'
 import { SYMBOL } from '../constants'
+import { useOnchainData } from '../hooks/useOnchainData'
 import { useRegister } from '../hooks/useRegister'
 import { useWallet } from '../hooks/useWallet'
 import { useRegistration } from '../states/registration'
@@ -26,8 +27,13 @@ import { useRegistration } from '../states/registration'
 const Page: React.FC = () => {
   const { extension, handleConnect } = useWallet()
   const { domainsOptions, handleChange, handleDomainChange, handleMaxAmountToStake, handleSubmit } = useRegister()
+  const { handleOnchainData } = useOnchainData()
   const { currentRegistration, isErrorsField } = useRegistration((state) => state)
   const { domainId, amountToStake, signingKey, minimumNominatorStake, nominatorTax } = currentRegistration
+
+  useEffect(() => {
+    handleOnchainData()
+  }, [handleOnchainData])
 
   return (
     <Box minW='60vw' maxW='60vw' mt='10' p='4' border='0'>

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -1,0 +1,29 @@
+import { Box, HStack, Heading } from '@chakra-ui/react'
+import React from 'react'
+import { Wallet } from '../components/icons'
+import { OperatorsList } from '../components/operatorsList'
+
+const Page: React.FC = () => {
+  return (
+    <Box minW='60vw' maxW='60vw' mt='10' p='4' border='0'>
+      <HStack>
+        <Wallet />
+        <Heading ml='2'>Stats</Heading>
+      </HStack>
+      <Box mt='6'>
+        <HStack mb='6'>
+          <Heading size='lg' fontWeight='500' fontSize='40px' ml='2' color='#5B5252'>
+            Information across operators
+          </Heading>
+        </HStack>
+      </Box>
+      <OperatorsList />
+    </Box>
+  )
+}
+
+export async function getStaticProps() {
+  return { props: { title: 'Subspace Staking Interface - Stats' } }
+}
+
+export default Page

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -2,6 +2,7 @@ import { Box, HStack, Heading } from '@chakra-ui/react'
 import React from 'react'
 import { Wallet } from '../components/icons'
 import { OperatorsList } from '../components/operatorsList'
+import { OperatorsTotal } from '../components/operatorsTotal'
 
 const Page: React.FC = () => {
   return (
@@ -18,6 +19,7 @@ const Page: React.FC = () => {
         </HStack>
       </Box>
       <OperatorsList />
+      <OperatorsTotal />
     </Box>
   )
 }

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -18,13 +18,6 @@ const Page: React.FC = () => {
         <Wallet />
         <Heading ml='2'>Stats</Heading>
       </HStack>
-      <Box mt='6'>
-        <HStack mb='6'>
-          <Heading size='lg' fontWeight='500' fontSize='40px' ml='2' color='#5B5252'>
-            Information across operators
-          </Heading>
-        </HStack>
-      </Box>
       <OperatorsList />
       <OperatorsTotal />
     </Box>

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -1,10 +1,17 @@
 import { Box, HStack, Heading } from '@chakra-ui/react'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Wallet } from '../components/icons'
 import { OperatorsList } from '../components/operatorsList'
 import { OperatorsTotal } from '../components/operatorsTotal'
+import { useOnchainData } from '../hooks/useOnchainData'
 
 const Page: React.FC = () => {
+  const { handleOnchainData } = useOnchainData()
+
+  useEffect(() => {
+    handleOnchainData()
+  }, [handleOnchainData])
+
   return (
     <Box minW='60vw' maxW='60vw' mt='10' p='4' border='0'>
       <HStack>

--- a/src/states/extension.ts
+++ b/src/states/extension.ts
@@ -7,11 +7,13 @@ import { AccountDetails, ExtensionState, StakingConstants } from '../types'
 interface RegistrationState {
   api: ApiPromise | undefined
   extension: ExtensionState
+  subspaceAccount: string | undefined
   injectedExtension: InjectedExtension | undefined
   accountDetails: AccountDetails | undefined
   stakingConstants: StakingConstants
   setApi: (api: ApiPromise) => void
   setExtension: (registration: ExtensionState) => void
+  setSubspaceAccount: (subspaceAccount: string) => void
   setInjectedExtension: (injectedExtension: InjectedExtension) => void
   setAccountDetails: (accountDetails: AccountDetails) => void
   setStakingConstants: (networkConstants: StakingConstants) => void
@@ -20,11 +22,13 @@ interface RegistrationState {
 export const useExtension = create<RegistrationState>((set) => ({
   api: undefined,
   extension: initialExtensionValues,
+  subspaceAccount: undefined,
   injectedExtension: undefined,
   accountDetails: undefined,
   stakingConstants: initialStakingConstants,
   setApi: (api) => set(() => ({ api })),
   setExtension: (extension) => set(() => ({ extension })),
+  setSubspaceAccount: (subspaceAccount) => set(() => ({ subspaceAccount })),
   setInjectedExtension: (injectedExtension) => set(() => ({ injectedExtension })),
   setAccountDetails: (accountDetails) => set(() => ({ accountDetails })),
   setStakingConstants: (stakingConstants) => set(() => ({ stakingConstants }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,7 @@ export type StakingConstants = {
   stakeWithdrawalLockingPeriod: number
   domainRegistry: DomainRegistry[]
   domainStakingSummary: DomainStakingSummary[]
-  operatorIdOwner: OperatorIdOwner[]
+  operatorIdOwner: string[]
   operators: Operators[]
   pendingStakingOperationCount: PendingStakingOperationCount[]
 }
@@ -65,10 +65,6 @@ export type DomainStakingSummary = {
   currentEpochRewards: {
     [key: string]: string
   }
-}
-
-export type OperatorIdOwner = {
-  [key: string]: string
 }
 
 export type Operators = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,10 @@
 export const formatAddress = (address: string) => `${address.slice(0, 4)}...${address.slice(-6)}`
 
-export const formatNumber = (number: number) => (Math.round(number * 100) / 100).toFixed(2).toLocaleString()
+export const formatNumber = (number: number, decimals = 4) =>
+  (Math.round(number * 100) / 100).toFixed(decimals).toLocaleString()
 
 export const capitalizeFirstLetter = (string: string) => string.charAt(0).toUpperCase() + string.slice(1)
 
-export const hexToFormattedNumber = (hex: string, decimals = 4) => (parseInt(hex, 16) / 10 ** 16).toFixed(decimals)
+export const hexToNumber = (hex: string) => parseInt(hex, 16) / 10 ** 16
+
+export const hexToFormattedNumber = (hex: string, decimals = 4) => formatNumber(hexToNumber(hex), decimals)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,5 @@ export const formatAddress = (address: string) => `${address.slice(0, 4)}...${ad
 export const formatNumber = (number: number) => (Math.round(number * 100) / 100).toFixed(2).toLocaleString()
 
 export const capitalizeFirstLetter = (string: string) => string.charAt(0).toUpperCase() + string.slice(1)
+
+export const hexToFormattedNumber = (hex: string, decimals = 4) => (parseInt(hex, 16) / 10 ** 16).toFixed(decimals)


### PR DESCRIPTION
## Add operator stat page

- From the stats page, click on a operatorId and get to a page with the stats of this specific operator (with a dynamic URL like ```http://localhost:3000/operatorStats/st94t7hVTXX5snydS8y2UWzyB97Mo8jfRK7etSJw9n4PvJm8c```

### Screenshot

![StatsPage](https://github.com/subspace/staking-interface/assets/82244926/2f7359bb-381a-4904-b890-8a1893742802)
![OperatorStatsPage](https://github.com/subspace/staking-interface/assets/82244926/04f91096-1098-4268-93a3-f5a84fa169c9)
