### PR TITLE
Filter all data by env domain id & persist last selected wallet (auto-reconect)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,5 @@
+# RPC URL of Subspace concensus chain
 NEXT_PUBLIC_PROVIDER_URL=""
+
+# Domain Id use for Stake War
+NEXT_PUBLIC_DOMAIN_ID="1"

--- a/src/components/actions.tsx
+++ b/src/components/actions.tsx
@@ -52,17 +52,8 @@ export const Actions: React.FC<ActionsProps> = ({ operatorId }) => {
   } = useManage()
 
   const operator = useMemo(
-    () => stakingConstants.operators.filter((operator) => operator.operatorId === operatorId)[0],
+    () => stakingConstants.operators.find((operator) => operator.operatorId === operatorId),
     [operatorId, stakingConstants.operators]
-  )
-  const operatorAccount = useMemo(
-    () =>
-      formatAddress(
-        stakingConstants.operatorIdOwner[
-          stakingConstants.operators.findIndex((operator) => operator.operatorId === operatorId)
-        ]
-      ),
-    [stakingConstants.operatorIdOwner, stakingConstants.operators, operatorId]
   )
 
   const handleClickOnAction = useCallback(
@@ -114,7 +105,7 @@ export const Actions: React.FC<ActionsProps> = ({ operatorId }) => {
           <ModalBody>
             <Center>
               <VStack>
-                <Text>Operator Account {operatorAccount}</Text>
+                <Text>Operator Account {operator && operator.operatorOwner}</Text>
                 <Text>
                   Signing Key{' '}
                   {operator && (

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -15,14 +15,13 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
   const subspaceAccount = useExtension((state) => state.subspaceAccount)
 
   const operators = useMemo(() => {
-    if (operatorOwner)
-      return stakingConstants.operators.filter((_, key) => stakingConstants.operatorIdOwner[key] === operatorOwner)
+    if (operatorOwner) return stakingConstants.operators.filter((operator) => operator.operatorOwner === operatorOwner)
     return stakingConstants.operators
-  }, [operatorOwner, stakingConstants.operatorIdOwner, stakingConstants.operators])
+  }, [operatorOwner, stakingConstants.operators])
 
   const isOneOfTheOperators = useMemo(
-    () => subspaceAccount && stakingConstants.operatorIdOwner.includes(subspaceAccount),
-    [stakingConstants.operatorIdOwner, subspaceAccount]
+    () => subspaceAccount && stakingConstants.operators.find((operator) => operator.operatorOwner === subspaceAccount),
+    [stakingConstants.operators, subspaceAccount]
   )
 
   return (
@@ -78,8 +77,8 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
                   </Td>
                   <Td {...textStyles.text}>{formatAddress(operator.operatorDetail.signingKey)}</Td>
                   <Td {...textStyles.link}>
-                    <Link href={`${ROUTES.OPERATOR_STATS}/${operatorOwner ?? stakingConstants.operatorIdOwner[key]}`}>
-                      {formatAddress(operatorOwner ?? stakingConstants.operatorIdOwner[key])}
+                    <Link href={`${ROUTES.OPERATOR_STATS}/${operatorOwner ?? operator.operatorOwner}`}>
+                      {formatAddress(operatorOwner ?? operator.operatorOwner)}
                     </Link>
                   </Td>
                   <Td {...textStyles.text} isNumeric>
@@ -91,15 +90,11 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
                   <Td {...textStyles.text} isNumeric>
                     {hexToFormattedNumber(operator.operatorDetail.currentTotalStake)}
                   </Td>
-                  {isOneOfTheOperators &&
-                    subspaceAccount &&
-                    stakingConstants.operatorIdOwner[
-                      stakingConstants.operators.findIndex((o) => o.operatorId === operator.operatorId)
-                    ] === subspaceAccount && (
-                      <Td {...textStyles.text}>
-                        <Actions operatorId={operator.operatorId} />
-                      </Td>
-                    )}
+                  {isOneOfTheOperators && subspaceAccount && operator.operatorOwner === subspaceAccount && (
+                    <Td {...textStyles.text}>
+                      <Actions operatorId={operator.operatorId} />
+                    </Td>
+                  )}
                 </Tr>
               ))}
             </Tbody>

--- a/src/components/operatorsTotal.tsx
+++ b/src/components/operatorsTotal.tsx
@@ -14,13 +14,13 @@ export const OperatorsTotal: React.FC<OperatorsTotalProps> = ({ operatorOwner })
   const totalFundsInStake = useMemo(() => {
     if (operatorOwner)
       return stakingConstants.operators
-        .filter((_, key) => stakingConstants.operatorIdOwner[key] === operatorOwner)
+        .filter((operator) => operator.operatorOwner === operatorOwner)
         .reduce((acc, operator) => acc + hexToNumber(operator.operatorDetail.currentTotalStake), 0)
     return stakingConstants.operators.reduce(
       (acc, operator) => acc + hexToNumber(operator.operatorDetail.currentTotalStake),
       0
     )
-  }, [operatorOwner, stakingConstants.operatorIdOwner, stakingConstants.operators])
+  }, [operatorOwner, stakingConstants.operators])
 
   // To-Do: Implement this
   const totalFundsInStakeAvailable = useMemo(() => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -60,7 +60,6 @@ export const initialStakingConstants: StakingConstants = {
   stakeWithdrawalLockingPeriod: 0,
   domainRegistry: [],
   domainStakingSummary: [],
-  operatorIdOwner: [],
   operators: [],
   pendingStakingOperationCount: []
 }

--- a/src/hooks/useManage.ts
+++ b/src/hooks/useManage.ts
@@ -1,9 +1,9 @@
 import { useToast } from '@chakra-ui/react'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 import { ActionType, DECIMALS, ERROR_DESC_INFORMATION_INCORRECT, toastConfig } from '../constants'
 import { useExtension } from '../states/extension'
 import { useManageState } from '../states/manage'
-import { capitalizeFirstLetter, formatAddress, formatNumber, parseNumber } from '../utils'
+import { capitalizeFirstLetter, formatNumber, parseNumber } from '../utils'
 import { useTx } from './useTx'
 
 export const useManage = () => {
@@ -20,20 +20,7 @@ export const useManage = () => {
   const setWithdrawAmount = useManageState((state) => state.setWithdrawAmount)
   const clearInput = useManageState((state) => state.clearInput)
   const { handleDeregister, handleAddFunds, handleWithdraw } = useTx()
-
-  const operatorsOptions = useMemo(
-    () =>
-      stakingConstants.operatorIdOwner
-        ? stakingConstants.operatorIdOwner.map((owner, key) => ({
-            label: `${stakingConstants.operators[key].operatorId} - ${formatAddress(owner)} - ${formatAddress(
-              stakingConstants.operators[key].operatorDetail.signingKey
-            )}`,
-            value: stakingConstants.operators[key].operatorId
-          }))
-        : [],
-    [stakingConstants.operatorIdOwner, stakingConstants.operators]
-  )
-
+  console.log('stakingConstants', stakingConstants)
   const operatorId = useCallback(
     (actionType: ActionType) => {
       switch (actionType) {
@@ -134,7 +121,6 @@ export const useManage = () => {
   )
 
   return {
-    operatorsOptions,
     operatorId,
     addFundsAmount,
     withdrawAmount,

--- a/src/hooks/useOnchainData.ts
+++ b/src/hooks/useOnchainData.ts
@@ -2,7 +2,14 @@ import { ApiPromise } from '@polkadot/api'
 import { WsProvider } from '@polkadot/rpc-provider'
 import { useCallback } from 'react'
 import { useExtension } from '../states/extension'
-import { DomainRegistry, DomainStakingSummary, OperatorDetail, Operators, PendingStakingOperationCount } from '../types'
+import {
+  DomainRegistry,
+  DomainRegistryDetail,
+  DomainStakingSummary,
+  OperatorDetail,
+  Operators,
+  PendingStakingOperationCount
+} from '../types'
 
 export const useOnchainData = () => {
   const setApi = useExtension((state) => state.setApi)
@@ -30,7 +37,12 @@ export const useOnchainData = () => {
           minOperatorStake: BigInt(minOperatorStake.toString()),
           stakeEpochDuration: Number(stakeEpochDuration.toString()),
           stakeWithdrawalLockingPeriod: Number(stakeWithdrawalLockingPeriod.toString()),
-          domainRegistry: domainRegistry.map((domain) => domain[1].toJSON() as DomainRegistry),
+          domainRegistry: domainRegistry.map((domain) => {
+            return {
+              domainId: (domain[0].toHuman() as string[])[0],
+              domainDetail: domain[1].toJSON() as DomainRegistryDetail
+            } as DomainRegistry
+          }),
           domainStakingSummary: domainStakingSummary.map((domain) => domain[1].toJSON() as DomainStakingSummary),
           operatorIdOwner: operatorIdOwner.map((operator) => operator[1].toJSON() as string),
           operators: operators.map((operator) => {

--- a/src/hooks/useOnchainData.ts
+++ b/src/hooks/useOnchainData.ts
@@ -44,10 +44,10 @@ export const useOnchainData = () => {
             } as DomainRegistry
           }),
           domainStakingSummary: domainStakingSummary.map((domain) => domain[1].toJSON() as DomainStakingSummary),
-          operatorIdOwner: operatorIdOwner.map((operator) => operator[1].toJSON() as string),
-          operators: operators.map((operator) => {
+          operators: operators.map((operator, key) => {
             return {
               operatorId: (operator[0].toHuman() as string[])[0],
+              operatorOwner: operatorIdOwner[key][1].toJSON() as string,
               operatorDetail: operator[1].toJSON() as OperatorDetail
             } as Operators
           }),

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -21,8 +21,6 @@ export const useRegister = () => {
   const stakingConstants = useExtension((state) => state.stakingConstants)
   const { handleRegisterOperator } = useTx()
 
-  const domainIdFiltering = useMemo(() => process.env.NEXT_PUBLIC_DOMAIN_ID || '0', [])
-
   const detectError = useCallback((key: string, value: string) => {
     switch (key) {
       case 'domainId':
@@ -43,14 +41,12 @@ export const useRegister = () => {
   const domainsOptions = useMemo(
     () =>
       stakingConstants.domainRegistry
-        ? stakingConstants.domainRegistry
-            .filter((domain) => domain.domainId === domainIdFiltering)
-            .map((domain) => ({
-              label: `${domain.domainId} - ${capitalizeFirstLetter(domain.domainDetail.domainConfig.domainName)}`,
-              value: domain.domainId
-            }))
+        ? stakingConstants.domainRegistry.map((domain) => ({
+            label: `${domain.domainId} - ${capitalizeFirstLetter(domain.domainDetail.domainConfig.domainName)}`,
+            value: domain.domainId
+          }))
         : [],
-    [domainIdFiltering, stakingConstants.domainRegistry]
+    [stakingConstants.domainRegistry]
   )
 
   const handleChange = useCallback(

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -21,6 +21,8 @@ export const useRegister = () => {
   const stakingConstants = useExtension((state) => state.stakingConstants)
   const { handleRegisterOperator } = useTx()
 
+  const domainIdFiltering = useMemo(() => process.env.NEXT_PUBLIC_DOMAIN_ID || '0', [])
+
   const detectError = useCallback((key: string, value: string) => {
     switch (key) {
       case 'domainId':
@@ -41,12 +43,14 @@ export const useRegister = () => {
   const domainsOptions = useMemo(
     () =>
       stakingConstants.domainRegistry
-        ? stakingConstants.domainRegistry.map((domain, key) => ({
-            label: `${key} - ${capitalizeFirstLetter(domain.domainConfig.domainName)}`,
-            value: key
-          }))
+        ? stakingConstants.domainRegistry
+            .filter((domain) => domain.domainId === domainIdFiltering)
+            .map((domain) => ({
+              label: `${domain.domainId} - ${capitalizeFirstLetter(domain.domainDetail.domainConfig.domainName)}`,
+              value: domain.domainId
+            }))
         : [],
-    [stakingConstants.domainRegistry]
+    [domainIdFiltering, stakingConstants.domainRegistry]
   )
 
   const handleChange = useCallback(
@@ -71,8 +75,8 @@ export const useRegister = () => {
   )
 
   const handleDomainChange = useCallback(
-    (domainSelected: SingleValue<Option<number>>) => {
-      const domainId = domainSelected != null ? domainSelected.value.toString() : ''
+    (domainSelected: SingleValue<Option<string>>) => {
+      const domainId = domainSelected != null ? domainSelected.value : ''
       saveCurrentRegistration({ ...currentRegistration, domainId })
       setErrorsField('domainId', detectError('domainId', domainId))
     },

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -48,7 +48,7 @@ const Page: React.FC = () => {
               <Box mt='6'>
                 <Select
                   name='domainId'
-                  value={domainsOptions.find((option) => option.value.toString() === domainId)}
+                  value={domainsOptions.find((option) => option.value === domainId)}
                   onChange={handleDomainChange}
                   options={domainsOptions}
                 />

--- a/src/states/extension.ts
+++ b/src/states/extension.ts
@@ -1,6 +1,7 @@
 import { ApiPromise } from '@polkadot/api'
 import { InjectedExtension } from '@polkadot/extension-inject/types'
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import { initialExtensionValues, initialStakingConstants } from '../constants'
 import { AccountDetails, ExtensionState, StakingConstants } from '../types'
 
@@ -19,6 +20,11 @@ interface RegistrationState {
   setStakingConstants: (networkConstants: StakingConstants) => void
 }
 
+interface LastConnection {
+  subspaceAccount: string | undefined
+  setSubspaceAccount: (subspaceAccount: string) => void
+}
+
 export const useExtension = create<RegistrationState>((set) => ({
   api: undefined,
   extension: initialExtensionValues,
@@ -33,3 +39,16 @@ export const useExtension = create<RegistrationState>((set) => ({
   setAccountDetails: (accountDetails) => set(() => ({ accountDetails })),
   setStakingConstants: (stakingConstants) => set(() => ({ stakingConstants }))
 }))
+
+export const useLastConnection = create<LastConnection>()(
+  persist(
+    (set) => ({
+      subspaceAccount: undefined,
+      setSubspaceAccount: (subspaceAccount) => set(() => ({ subspaceAccount }))
+    }),
+    {
+      name: 'lastConnection',
+      version: 1
+    }
+  )
+)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,11 @@ export type StakingConstants = {
 }
 
 export type DomainRegistry = {
+  domainId: string
+  domainDetail: DomainRegistryDetail
+}
+
+export type DomainRegistryDetail = {
   ownerAccountId: string
   createdAt: number
   genesisReceiptHash: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,6 @@ export type StakingConstants = {
   stakeWithdrawalLockingPeriod: number
   domainRegistry: DomainRegistry[]
   domainStakingSummary: DomainStakingSummary[]
-  operatorIdOwner: string[]
   operators: Operators[]
   pendingStakingOperationCount: PendingStakingOperationCount[]
 }
@@ -86,6 +85,7 @@ export type OperatorDetail = {
 
 export type Operators = {
   operatorId: string
+  operatorOwner: string
   operatorDetail: OperatorDetail
 }
 


### PR DESCRIPTION
## Filter all data by env domain id & persist last selected wallet (auto-reconect)

- #13 
- #25 

Add in `.env`
```txt
NEXT_PUBLIC_DOMAIN_ID="1"
```
And the web app will filter to show only this domain in the dropdown on /register and only this domain info will show in /stats and /manage


### Note before merging

We will need to add this env on Netlify