### PR TITLE
Add full token amount precision with tooltip

### DIFF
--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -4,8 +4,9 @@ import Link from 'next/link'
 import React, { useMemo } from 'react'
 import { ROUTES, headingStyles, tHeadStyles, tableStyles, textStyles } from '../constants'
 import { useExtension } from '../states/extension'
-import { formatAddress, hexToFormattedNumber } from '../utils'
+import { formatAddress, hexToFormattedNumber, hexToNumber } from '../utils'
 import { Actions } from './actions'
+import { TooltipAmount } from './tooltipAmount'
 
 interface OperatorsListProps {
   operatorOwner?: string
@@ -88,10 +89,14 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner }) =
                       {operator.operatorDetail.nominationTax}%
                     </Td>
                     <Td {...textStyles.text} isNumeric>
-                      {hexToFormattedNumber(operator.operatorDetail.minimumNominatorStake)}
+                      <TooltipAmount amount={hexToNumber(operator.operatorDetail.minimumNominatorStake)}>
+                        {hexToFormattedNumber(operator.operatorDetail.minimumNominatorStake)}
+                      </TooltipAmount>
                     </Td>
                     <Td {...textStyles.text} isNumeric>
-                      {hexToFormattedNumber(operator.operatorDetail.currentTotalStake)}
+                      <TooltipAmount amount={hexToNumber(operator.operatorDetail.currentTotalStake)}>
+                        {hexToFormattedNumber(operator.operatorDetail.currentTotalStake)}
+                      </TooltipAmount>
                     </Td>
                     {isOneOfTheOperators && subspaceAccount && operator.operatorOwner === subspaceAccount && (
                       <Td {...textStyles.text}>

--- a/src/components/operatorsTotal.tsx
+++ b/src/components/operatorsTotal.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 import { headingStyles, textStyles } from '../constants'
 import { useExtension } from '../states/extension'
 import { formatAddress, formatNumber, hexToNumber } from '../utils'
+import { TooltipAmount } from './tooltipAmount'
 
 interface OperatorsTotalProps {
   operatorOwner?: string
@@ -51,7 +52,9 @@ export const OperatorsTotal: React.FC<OperatorsTotalProps> = ({ operatorOwner })
       <Grid templateColumns='repeat(2, 1fr)' gap={6} mt='12'>
         <GridItem w='100%'>
           <Text style={textStyles.heading}>Funds in Stake, {tokenSymbol}</Text>
-          <Text style={textStyles.value}>{formatNumber(totalFundsInStake)}</Text>
+          <Text style={textStyles.value}>
+            <TooltipAmount amount={totalFundsInStake}>{formatNumber(totalFundsInStake)}</TooltipAmount>
+          </Text>
 
           <Text style={textStyles.heading} mt='8'>
             Number of Nominators
@@ -60,12 +63,18 @@ export const OperatorsTotal: React.FC<OperatorsTotalProps> = ({ operatorOwner })
         </GridItem>
         <GridItem w='100%'>
           <Text style={textStyles.heading}>Available for withdrawal, {tokenSymbol}</Text>
-          <Text style={textStyles.value}>{formatNumber(totalFundsInStakeAvailable)}</Text>
+          <Text style={textStyles.value}>
+            <TooltipAmount amount={totalFundsInStakeAvailable}>
+              {formatNumber(totalFundsInStakeAvailable)}
+            </TooltipAmount>
+          </Text>
 
           <Text style={textStyles.heading} mt='8'>
             Nominator’s funds, {tokenSymbol}
           </Text>
-          <Text style={textStyles.value}>{formatNumber(totalNominatorsStake)}</Text>
+          <Text style={textStyles.value}>
+            <TooltipAmount amount={totalNominatorsStake}>{formatNumber(totalNominatorsStake)}</TooltipAmount>
+          </Text>
         </GridItem>
       </Grid>
     </Box>

--- a/src/components/tooltipAmount.tsx
+++ b/src/components/tooltipAmount.tsx
@@ -1,0 +1,22 @@
+import { Tooltip } from '@chakra-ui/react'
+import React from 'react'
+import { SYMBOL } from '../constants'
+
+interface TooltipAmountProps {
+  children: React.ReactNode
+  amount: number | string
+  symbol?: string
+}
+
+export const TooltipAmount: React.FC<TooltipAmountProps> = ({ children, amount, symbol = SYMBOL }) => {
+  return (
+    <Tooltip
+      hasArrow
+      label={`${amount} ${symbol}`}
+      aria-label={`${amount} ${symbol}`}
+      placement='bottom'
+      bg='brand.500'>
+      {children}
+    </Tooltip>
+  )
+}

--- a/src/components/walletDetails.tsx
+++ b/src/components/walletDetails.tsx
@@ -18,7 +18,7 @@ const TokenBalanceSection: React.FC = () => {
       {subspaceAccount && (
         <>
           <TokenBalance />
-          <Tooltip hasArrow label='Account balance' aria-label='Account balance' placement='bottom'>
+          <Tooltip hasArrow label='Account balance' aria-label='Account balance' placement='bottom' bg='brand.500'>
             <Text whiteSpace='nowrap'>
               {accountBalance} {tokenSymbol}
             </Text>


### PR DESCRIPTION
## Add full token amount precision with tooltip

- #52 

### Screenshot

![image](https://github.com/subspace/staking-interface/assets/82244926/778eef87-6539-4a3a-acff-05ba318d333e)