### PR TITLE
Add Index a column to improve data readability in total stake list

### DIFF
--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -42,6 +42,7 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner, fro
         <Table {...tableStyles}>
           <Thead {...tHeadStyles}>
             <Tr>
+              <Th isNumeric />
               <Th>OperatorID</Th>
               <Th>Signing key</Th>
               <Th>Operator Account</Th>
@@ -56,7 +57,7 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner, fro
             <Tbody>
               {[0].map((_, key) => (
                 <Tr key={key}>
-                  <Td {...textStyles.text} colSpan={subspaceAccount ? 7 : 6}>
+                  <Td {...textStyles.text} colSpan={subspaceAccount ? 8 : 7}>
                     <Text>No operators found</Text>
                     {subspaceAccount === operatorOwner && (
                       <Text>
@@ -82,6 +83,9 @@ export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner, fro
                     .length - 1
                 return (
                   <Tr key={key}>
+                    <Td {...textStyles.text} isNumeric>
+                      {key + 1}
+                    </Td>
                     <Td {...textStyles.text} isNumeric>
                       {operator.operatorId}
                     </Td>

--- a/src/components/operatorsList.tsx
+++ b/src/components/operatorsList.tsx
@@ -17,9 +17,8 @@ interface OperatorsListProps {
 
 export const OperatorsList: React.FC<OperatorsListProps> = ({ operatorOwner, fromManage }) => {
   const [clientSide, setClientSide] = useState(false)
-  const { extension, subspaceAccount, chainDetails, stakingConstants } = useExtension((state) => state)
+  const { extension, subspaceAccount, chainDetails, stakingConstants } = useExtension()
   const { ss58Format } = chainDetails
-
   const { orderedOperators } = useOrderedOperators({ operatorOwner, fromManage })
 
   useEffect(() => {


### PR DESCRIPTION
## Add a Index column to improve data readability in total stake list

- #72 

### Screenshot

![AddIndexInOperatorsList](https://github.com/subspace/staking-interface/assets/82244926/a549ea7b-ce67-4f33-b7d4-d24770bd3d80)
