### PR TITLE
Fix Potential Labeling Issue in Nominators List

### DIFF
--- a/src/components/nominatorsList.tsx
+++ b/src/components/nominatorsList.tsx
@@ -75,11 +75,11 @@ export const NominatorsList: React.FC<OperatorsListProps> = ({ operatorId }) => 
                     operator &&
                     extension.data &&
                     extension.data.accounts.find((a) => encodeAddress(a.address, ss58Format) === operator.operatorOwner)
+                  const isOperator = operator?.operatorOwner === nominator.nominatorOwner
                   const accountLabel =
-                    findMatchingAccount && findMatchingAccount.meta.name
+                    findMatchingAccount && findMatchingAccount.meta.name && isOperator
                       ? `(${findMatchingAccount.meta.name}) ${formatAddress(nominator.nominatorOwner)}`
                       : formatAddress(nominator.nominatorOwner)
-                  const isOperator = operator?.operatorOwner === nominator.nominatorOwner
                   const fundsInStake = calculateSharedToStake(
                     nominator.shares,
                     operator?.operatorDetail.totalShares ?? '0x0',


### PR DESCRIPTION
Context:
While working with the staking interface as an operator, I noticed that the operator's name was being appended to all nominators in the nominators list, which may not be accurate. Operator meta was labeled across multiple nominator accounts, whereas it should only be associated with the operator's account.

**Change:**
I have modified the logic for assigning labels to nominator accounts. The updated code ensures that the operator’s name is appended only to the operator's account, rather than to all nominators.

**Uncertainty:**
I'm not entirely sure if this behavior was intentional or a bug. However, from a usability standpoint, it seemed potentially misleading, prompting this proposed change.

**Request for Feedback:**
I would appreciate feedback on this change. If my understanding of the issue is incorrect, or if there’s a better way to address it, I am open to suggestions and further discussion.