### PR TITLE
Switch to use the All option to withdraw when using the max option

### DIFF
--- a/src/hooks/useManage.ts
+++ b/src/hooks/useManage.ts
@@ -135,8 +135,8 @@ export const useManage = () => {
         : 0
       setWithdrawAmount({
         ...withdrawAmount,
-        amount: amount.toString(),
-        formattedAmount: formatNumber(amount / 10 ** tokenDecimals)
+        amount: 'max',
+        formattedAmount: `Max (≃${formatNumber(amount / 10 ** tokenDecimals)})`
       })
     } catch (error) {
       console.error('Error: ', error)

--- a/src/hooks/useTx.tsx
+++ b/src/hooks/useTx.tsx
@@ -145,9 +145,7 @@ export const useTx = () => {
       if (extension.data) {
         const block = await api.rpc.chain.getBlock()
         const hash = await api.tx.domains
-          .withdrawStake(operatorId, {
-            Some: amount
-          })
+          .withdrawStake(operatorId, amount === 'max' ? { All: null } : { Some: amount })
           .signAndSend(extension.data?.defaultAccount.address, { signer: injectedExtension.signer })
         addTransactionToWatch({
           extrinsicHash: hash.toString(),


### PR DESCRIPTION
## Switch to use the All option to withdraw when using the max option

The withdrawStake function can be used with a specific amount using the `Some` and amount, but it also accepts an `All` input that automatically withdraws everything.